### PR TITLE
Added support for Edits endpoint & other improvements

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -10,25 +10,21 @@ import (
 
 // CompletionRequest represents a request structure for completion API
 type CompletionRequest struct {
-	Prompt    string `json:"prompt,omitempty"`
-	MaxTokens int    `json:"max_tokens,omitempty"`
-
-	Temperature float32 `json:"temperature,omitempty"`
-	TopP        float32 `json:"top_p,omitempty"`
-
-	N int `json:"n,omitempty"`
-
-	LogProbs int `json:"logprobs,omitempty"`
-
-	Model *string `json:"model,omitempty"`
-
-	Echo bool     `json:"echo,omitempty"`
-	Stop []string `json:"stop,omitempty"`
-
+	Model            *string        `json:"model,omitempty"`
+	Prompt           string         `json:"prompt,omitempty"`
+	MaxTokens        int            `json:"max_tokens,omitempty"`
+	Temperature      float32        `json:"temperature,omitempty"`
+	TopP             float32        `json:"top_p,omitempty"`
+	N                int            `json:"n,omitempty"`
+	Stream           bool           `json:"stream,omitempty"`
+	LogProbs         int            `json:"logprobs,omitempty"`
+	Echo             bool           `json:"echo,omitempty"`
+	Stop             []string       `json:"stop,omitempty"`
 	PresencePenalty  float32        `json:"presence_penalty,omitempty"`
 	FrequencyPenalty float32        `json:"frequency_penalty,omitempty"`
 	BestOf           int            `json:"best_of,omitempty"`
 	LogitBias        map[string]int `json:"logit_bias,omitempty"`
+	User             string         `json:"user,omitempty"`
 }
 
 // Choice represents one of possible completions
@@ -47,13 +43,21 @@ type LogprobResult struct {
 	TextOffset    []int                `json:"text_offset"`
 }
 
+// CompletionUsage represents Usage of CompletionResponse
+type CompletionUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
 // CompletionResponse represents a response structure for completion API
 type CompletionResponse struct {
-	ID      string   `json:"id"`
-	Object  string   `json:"object"`
-	Created uint64   `json:"created"`
-	Model   string   `json:"model"`
-	Choices []Choice `json:"choices"`
+	ID      string          `json:"id"`
+	Object  string          `json:"object"`
+	Created uint64          `json:"created"`
+	Model   string          `json:"model"`
+	Choices []Choice        `json:"choices"`
+	Usage   CompletionUsage `json:"usage"`
 }
 
 // CreateCompletion — API call to create a completion. This is the main endpoint of the API. Returns new text as well as, if requested, the probabilities over each alternative token at each position.

--- a/edits.go
+++ b/edits.go
@@ -1,0 +1,57 @@
+package gogpt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// EditsRequest represents a request structure for Edits API
+type EditsRequest struct {
+	Model       *string `json:"model,omitempty"`
+	Input       string  `json:"input,omitempty"`
+	Instruction string  `json:"instruction,omitempty"`
+	N           int     `json:"n,omitempty"`
+	Temperature float32 `json:"temperature,omitempty"`
+	TopP        float32 `json:"top_p,omitempty"`
+}
+
+// EditsUsage represents Usage of EditsResponse
+type EditsUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// Choice represents one of possible edits
+type Choice struct {
+	Text  string `json:"text"`
+	Index int    `json:"index"`
+}
+
+// EditsResponse represents a response structure for Edits API
+type EditsResponse struct {
+	Object  string     `json:"object"`
+	Created uint64     `json:"created"`
+	Usage   EditsUsage `json:"usage"`
+	Choices []Choice   `json:"choices"`
+}
+
+// Perform an API call to the Edits endpoint.
+func (c *Client) Edits(ctx context.Context, request EditsRequest) (response EditsResponse, err error) {
+	var reqBytes []byte
+	reqBytes, err = json.Marshal(request)
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequest("POST", c.fullURL("/edits"), bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return
+	}
+
+	req = req.WithContext(ctx)
+	err = c.sendRequest(req, &response)
+	return
+}

--- a/moderation.go
+++ b/moderation.go
@@ -15,9 +15,9 @@ type ModerationRequest struct {
 
 // Result represents one of possible moderation results
 type Result struct {
-	Categories     []ResultCategories     `json:"categories"`
-	CategoryScores []ResultCategoryScores `json:"category_scores"`
-	Flagged        int                    `json:"flagged"`
+	Categories     ResultCategories     `json:"categories"`
+	CategoryScores ResultCategoryScores `json:"category_scores"`
+	Flagged        int                  `json:"flagged"`
 }
 
 // ResultCategories represents Categories of Result


### PR DESCRIPTION
Added `edits.go` and did some minor changes.
Here are the details:
- Support for [Edits endpoint](https://beta.openai.com/docs/api-reference/edits) as per https://github.com/sashabaranov/go-gpt3/issues/17
- Added `Usage` to `CompletionResponse` so now devs could know how much tokens they've used for each completion.
- Added `Stream` & `User` to `CompletionRequest` — more parameters are better than none? it gives more flexibility to devs.
- Did a `go fmt` on `completion.go`, `moderation.go`, and `edits.go`.