### PR TITLE
fix: Choice redeclared in this block

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -27,8 +27,8 @@ type CompletionRequest struct {
 	User             string         `json:"user,omitempty"`
 }
 
-// Choice represents one of possible completions
-type Choice struct {
+// CompletionChoice represents one of possible completions
+type CompletionChoice struct {
 	Text         string        `json:"text"`
 	Index        int           `json:"index"`
 	FinishReason string        `json:"finish_reason"`
@@ -52,12 +52,12 @@ type CompletionUsage struct {
 
 // CompletionResponse represents a response structure for completion API
 type CompletionResponse struct {
-	ID      string          `json:"id"`
-	Object  string          `json:"object"`
-	Created uint64          `json:"created"`
-	Model   string          `json:"model"`
-	Choices []Choice        `json:"choices"`
-	Usage   CompletionUsage `json:"usage"`
+	ID      string             `json:"id"`
+	Object  string             `json:"object"`
+	Created uint64             `json:"created"`
+	Model   string             `json:"model"`
+	Choices []CompletionChoice `json:"choices"`
+	Usage   CompletionUsage    `json:"usage"`
 }
 
 // CreateCompletion — API call to create a completion. This is the main endpoint of the API. Returns new text as well as, if requested, the probabilities over each alternative token at each position.

--- a/edits.go
+++ b/edits.go
@@ -24,18 +24,18 @@ type EditsUsage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
-// Choice represents one of possible edits
-type Choice struct {
+// EditsChoice represents one of possible edits
+type EditsChoice struct {
 	Text  string `json:"text"`
 	Index int    `json:"index"`
 }
 
 // EditsResponse represents a response structure for Edits API
 type EditsResponse struct {
-	Object  string     `json:"object"`
-	Created uint64     `json:"created"`
-	Usage   EditsUsage `json:"usage"`
-	Choices []Choice   `json:"choices"`
+	Object  string        `json:"object"`
+	Created uint64        `json:"created"`
+	Usage   EditsUsage    `json:"usage"`
+	Choices []EditsChoice `json:"choices"`
 }
 
 // Perform an API call to the Edits endpoint.


### PR DESCRIPTION
This fixes the following errors:
- `edits.go:28:6: Choice redeclared in this block`
- `completion.go:31:6: other declaration of Choice`
